### PR TITLE
Add option to specify base source directory

### DIFF
--- a/lib/middleman-angular-templates.rb
+++ b/lib/middleman-angular-templates.rb
@@ -1,20 +1,29 @@
 require "middleman-core"
 
 class AngularTemplates < ::Middleman::Extension
+  option :base_dir, nil, 'Base diretory to Angular template partials'
 
-  def initialize(app, options_hash={}, &block)
-    super
+  def after_configuration
+    @@base_dir = options.base_dir
   end
 
   helpers do
     def angular_include_templates(path = '')
-      base_dir = Pathname.new('source')
+      base_dir = Pathname.new(@@base_dir || config.source)
+      source_dir = Pathname.new(config.source)
       ''.tap do |html|
         Dir[File.join(base_dir, path, '**/*.{html,erb,slim,haml}')].each do |filename|
           template_name = File.basename(filename, '.*')
           next unless template_name.slice!(0) == '_'
-          template_path = Pathname.new(File.join(File.dirname(filename), template_name)).relative_path_from(base_dir)
-          html << content_tag(:script, partial(template_path), type: "text/ng-template", id: "#{template_path}.html")
+          template_path = Pathname.new(File.join(File.dirname(filename), template_name))
+          template_id = template_path.relative_path_from(base_dir)
+          html << content_tag(
+            :script,
+            partial(
+              template_path.relative_path_from(source_dir)),
+              type: "text/ng-template",
+              id: "#{template_id}.html"
+          )
         end
       end
     end


### PR DESCRIPTION
Hi,

I added a option to configure base_dir for template sources.

For example, directory like this:

```
source
  ├── index.slim
  └── ng-templates
        └── logout.slim
```

index.slim:

``` slim
== angular_include_templates 'ng-templates'
```

The path filled in `id` attribute would be related from `source` directory by default:

``` html
<script type="text/ng-template" id="ng-templates/logout.html">
  <a href="/logout">Logout</a>
</script>
```

With this option:

``` rb
activate :angular_templates, base_dir: 'source/ng-templates'
```

index.slim:

``` slim
== angular_include_templates
```

The path would be related from the path specified with `:base_dir` option

``` html
<script type="text/ng-template" id="logout.html">
  <a href="/logout">Logout</a>
</script>
```
